### PR TITLE
画像容量が大きい(10MB以上)場合は画像を圧縮してDiscordに送信する

### DIFF
--- a/VRChat_Screenshot_Discord/Form1.vb
+++ b/VRChat_Screenshot_Discord/Form1.vb
@@ -5,6 +5,8 @@ Imports System.Text.RegularExpressions
 Imports System.Configuration
 Imports Newtonsoft.Json
 Imports System.Reflection
+Imports System.Drawing
+Imports System.Drawing.Imaging
 
 Public Class Form1
     Private watcher As FileSystemWatcher
@@ -332,11 +334,96 @@ Public Class Form1
             Dim jsonString As String = JsonConvert.SerializeObject(jsonPayload)
             Dim content = New StringContent(jsonString, Encoding.UTF8, "application/json")
 
-            ' 画像を添付する
+            ' リクエストの作成
             Dim boundary As String = "----WebKitFormBoundary" & DateTime.Now.Ticks.ToString("x")
             Dim multipartContent = New MultipartFormDataContent(boundary)
             multipartContent.Add(content, "payload_json")
+
+            ' 画像の容量
+            Dim originalFileSize As Long = New FileInfo(imagePath).Length
+            ' Discordの上限容量
+            Dim targetFileSize As Long = 10 * 1024 * 1024 ' 10MB
+
+            ' Discordの上限を超えたら画像を圧縮する
+            If originalFileSize > targetFileSize Then
+                ' 初期圧縮率は100%
+                Dim quality As Long = 100 
+
+                ' 圧縮率の決め打ちで圧縮をかける(処理は少ないが，画質の劣化が激しい)
+                ' Using originalImage As Image = Image.FromFile(imagePath)
+                '     ' https://qiita.com/sonoshou/items/4e7d58ee3124973085bc
+                '     quality = ((targetFileSize / 1024) / Math.Sqrt(3 * originalImage.Width * originalImage.Height)) * 100
+                '     Dim jpegEncoder As ImageCodecInfo = ImageCodecInfo.GetImageDecoders().First(Function(c) c.FormatID = ImageFormat.Jpeg.Guid)
+                '     Dim encoderParams As New EncoderParameters(1)
+                '     encoderParams.Param(0) = New EncoderParameter(System.Drawing.Imaging.Encoder.Quality, quality)
+
+                '     ' メモリストリームに書き出して添付する
+                '     Using ms As New MemoryStream()
+                '         originalImage.Save(ms, jpegEncoder, encoderParams)
+                '         ms.Seek(0, SeekOrigin.Begin)
+
+                '         ' 圧縮した画像を添付する
+                '         multipartContent.Add(New ByteArrayContent(ms.ToArray()), "file", Path.GetFileName(imagePath))
+                        
+                '         ' デバッグ用メッセージ
+                '         ' 圧縮後のファイルサイズを取得
+                '         ' Dim compressedFileSize As Long = ms.Length
+                '         ' InvokeIfRequired(Sub() ListBox1.Items.Add("originalImage: " & Math.Floor(originalFileSize / 10e5 * 100) / 100 & "MB compressedImage: " & Math.Floor(compressedFileSize / 10e5 * 100) / 100 & "MB quality: " & quality & "%"))
+                '     End Using
+                ' End Using
+
+
+                ' ' 圧縮後のファイルサイズによって２部探索で圧縮率を決定する
+                Dim minQuality As Long = 10
+                Dim maxQuality As Long = 100
+                Dim jpegEncoder As ImageCodecInfo = ImageCodecInfo.GetImageDecoders().First(Function(c) c.FormatID = ImageFormat.Jpeg.Guid)
+
+                Using originalImage As Image = Image.FromFile(imagePath)
+
+                    ' 二分探索で最適な品質を探す
+                    While minQuality <= maxQuality
+                        Dim midQuality As Long = (minQuality + maxQuality) / 2
+
+                        Dim encoderParams As New EncoderParameters(1)
+                        encoderParams.Param(0) = New EncoderParameter(System.Drawing.Imaging.Encoder.Quality, midQuality)
+
+                        Using ms As New MemoryStream()
+                            originalImage.Save(ms, jpegEncoder, encoderParams)
+                            Dim fileSize As Long = ms.Length
+
+                            If fileSize <= targetFileSize Then
+                                quality = midQuality
+                                minQuality = midQuality + 1
+                            Else
+                                maxQuality = midQuality - 1
+                            End If
+                        End Using
+                    End While
+
+                    ' 最適な品質で保存
+                    Dim finalParams As New EncoderParameters(1)
+                    finalParams.Param(0) = New EncoderParameter(System.Drawing.Imaging.Encoder.Quality, quality)
+
+                    ' メモリストリームに書き出して添付する
+                    Using ms As New MemoryStream()
+                        originalImage.Save(ms, jpegEncoder, finalParams)
+                        ms.Seek(0, SeekOrigin.Begin)
+
+                        ' 圧縮した画像を添付する
+                        multipartContent.Add(New ByteArrayContent(ms.ToArray()), "file", Path.GetFileName(imagePath))
+                        
+                        ' デバッグ用メッセージ
+                        ' 圧縮後のファイルサイズを取得
+                        ' Dim compressedFileSize As Long = ms.Length
+                        ' InvokeIfRequired(Sub() ListBox1.Items.Add("originalImage: " & Math.Floor(originalFileSize / 10e5 * 100) / 100 & "MB compressedImage: " & Math.Floor(compressedFileSize / 10e5 * 100) / 100 & "MB quality: " & quality & "%"))
+                    End Using
+
+                End Using
+        
+            Else
+                ' 画像を添付する
             multipartContent.Add(New ByteArrayContent(File.ReadAllBytes(imagePath)), "file", Path.GetFileName(imagePath))
+            End If
 
             Dim response = Await httpClient.PostAsync(webhookUrl, multipartContent)
             If response.IsSuccessStatusCode Then


### PR DESCRIPTION
# 初めまして。
v1.1.0.0を使用している際に、私の環境で改良した変更を共有します。
マージしていただいても、破棄していただいても、さらに改良していただいても構いません。

# 改良内容
現在の実装では，FHDの画像は問題なく送信できますが，8Kなどの高解像度画像を送信する際，Discordのファイルサイズ制限（10MB）を超えるため `413 Payload Too Large` エラーが発生します．
> Discord Nitroを用いたらどうかなど，詳しい仕様についてはわかりませんので悪しからず．．．

![スクリーンショット 2025-02-26 191230](https://github.com/user-attachments/assets/b4c39983-a975-465a-9001-5273c4d1dda8)

そこで，SendToDiscord 関数を改修し，以下の処理を追加しました．

- Discordの容量制限（10MB）を考慮し，画像の圧縮率を調整する処理を追加
- 圧縮率を単純計算で求める方法では，画質が過度に劣化してしまうため，二分探索を用いて最適な画質を維持しつつ10MB以下に収まるように調整

# パフォーマンス影響
8K画像の処理時に以下のリソースを消費することを確認しています．

メモリ使用量: 約200MB
CPU使用率: 4%〜10%

# 検証環境
OS: Microsoft Windows 11 Home 10.0.26100
.NET SDK: 5.0.406
CPU: Ryzen 7 5700X3D
GPU: RTX 4070 Ti Super
メモリ: DDR4 48GB

# その他
コメントには圧縮率を単純計算で求める方法も記載していますが，適切な圧縮率を得るために二分探索を採用しました．
初めてVBを書いたため，コードの書き方について不備があるかもしれません．

よろしくお願いいたします．

